### PR TITLE
Added functionality to strip the subdomain

### DIFF
--- a/lib/hedwig/config.ex
+++ b/lib/hedwig/config.ex
@@ -9,6 +9,7 @@ defmodule Hedwig.Config do
   def normalize(client) do
     config = (client[:config] || %{})
     |> Map.put_new(:server, server_from_jid(client.jid))
+    |> Map.put_new(:strip_subdomain, false)
     |> Map.put_new(:port, 5222)
     |> Map.put_new(:require_tls?, false)
     |> Map.put_new(:use_compression?, false)

--- a/lib/hedwig/conn.ex
+++ b/lib/hedwig/conn.ex
@@ -67,7 +67,7 @@ defmodule Hedwig.Conn do
   end
 
   def start_stream(%Conn{transport: mod, config: config} = conn) do
-    mod.send(conn, Stanza.start_stream(config.server))
+    mod.send(conn, Stanza.start_stream(config.server, config.strip_subdomain))
     recv(conn, :starting_stream)
     conn
   end

--- a/lib/hedwig/stanza.ex
+++ b/lib/hedwig/stanza.ex
@@ -35,7 +35,7 @@ defmodule Hedwig.Stanza do
 
   ## Example
 
-      iex> stanza = Hedwig.Stanza.start_stream("im.capulet.lit")
+      iex> stanza = Hedwig.Stanza.start_stream("im.capulet.lit", false)
       {:xmlstreamstart, "stream:stream",
        [{"to", "im.capulet.lit"}, {"version", "1.0"}, {"xml:lang", "en"},
          {"xmlns", "jabber:client"},
@@ -43,7 +43,8 @@ defmodule Hedwig.Stanza do
       iex> Hedwig.Stanza.to_xml(stanza)
       "<stream:stream xmlns:stream='http://etherx.jabber.org/streams' xmlns='jabber:client' xml:lang='en' version='1.0' to='im.capulet.lit'>"
   """
-  def start_stream(server, xmlns \\ ns_jabber_client) do
+  def start_stream(server, strip_subdomain, xmlns \\ ns_jabber_client) do
+    if strip_subdomain, do: [_, server] = String.split(server, ".", parts: 2)
     xmlstreamstart(name: "stream:stream",
       attrs: [
         {"to", server},

--- a/test/hedwig/stanza_test.exs
+++ b/test/hedwig/stanza_test.exs
@@ -7,12 +7,17 @@ defmodule Hedwig.StanzaTest do
   doctest Hedwig.Stanza
 
   test "start_stream with default xmlns" do
-    assert Stanza.start_stream("im.wonderland.lit") |> Stanza.to_xml ==
+    assert Stanza.start_stream("im.wonderland.lit", false) |> Stanza.to_xml ==
       "<stream:stream xmlns:stream='#{ns_xmpp}' xmlns='jabber:client' xml:lang='en' version='1.0' to='im.wonderland.lit'>"
   end
 
+  test "start_stream with strip_subdomain set to true" do
+    assert Stanza.start_stream("im.wonderland.lit", true) |> Stanza.to_xml ==
+      "<stream:stream xmlns:stream='#{ns_xmpp}' xmlns='jabber:client' xml:lang='en' version='1.0' to='wonderland.lit'>"
+  end
+
   test "start_stream with 'jabber:server' xmlns" do
-    assert Stanza.start_stream("im.wonderland.lit", ns_jabber_server) |> Stanza.to_xml ==
+    assert Stanza.start_stream("im.wonderland.lit", false, ns_jabber_server) |> Stanza.to_xml ==
       "<stream:stream xmlns:stream='http://etherx.jabber.org/streams' xmlns='jabber:server' xml:lang='en' version='1.0' to='im.wonderland.lit'>"
   end
 


### PR DESCRIPTION
I added the functionality to strip a subdomain from the server in the ``to`` stanza in ``Hedwig.Stanza.start_stream\3``.
I did this by adding a boolean ``strip_subdomain`` to the config map (default false). If set to true, the ``server`` variable will be split in a subdomain and server.
I also updated the tests to work with the new ``start_stream`` implementation.