### PR TITLE
Shorten regular expression for panzy script.

### DIFF
--- a/lib/hedwig/handlers/panzy.ex
+++ b/lib/hedwig/handlers/panzy.ex
@@ -11,7 +11,7 @@ defmodule Hedwig.Handlers.Panzy do
 
   def handle_event(%Message{} = msg, opts) do
     cond do
-      hear ~r/tired|too hard|to hard|upset|bored/i, msg ->
+      hear ~r/tired|too? hard|upset|bored/i, msg ->
         panzy!(msg)
       true ->
         :ok


### PR DESCRIPTION
The sections `too hard` and `to hard` are identical except one letter, so I made that extra letter optional and removed the second item. This simplified version is much easier to read.