### PR TITLE
Fix Credo warnings

### DIFF
--- a/lib/hedwig/robot.ex
+++ b/lib/hedwig/robot.ex
@@ -45,11 +45,11 @@ defmodule Hedwig.Robot do
       use GenServer
       require Logger
 
-      {otp_app, adapter, config} = Hedwig.Robot.Supervisor.parse_config(__MODULE__, opts)
+      {otp_app, adapter, robot_config} = Hedwig.Robot.Supervisor.parse_config(__MODULE__, opts)
       @adapter adapter
       @before_compile adapter
-      @config  config
-      @log_level config[:log_level] || :debug
+      @config  robot_config
+      @log_level robot_config[:log_level] || :debug
       @otp_app otp_app
 
       def start_link(opts \\ []) do

--- a/lib/hedwig/robot/supervisor.ex
+++ b/lib/hedwig/robot/supervisor.ex
@@ -11,8 +11,8 @@ defmodule Hedwig.Robot.Supervisor do
   end
 
   def config(robot, otp_app, opts) do
-    if config = Application.get_env(otp_app, robot) do
-      config
+    if robot_config = Application.get_env(otp_app, robot) do
+      robot_config
       |> Keyword.put(:otp_app, otp_app)
       |> Keyword.put(:robot, robot)
       |> Keyword.merge(opts)
@@ -24,8 +24,8 @@ defmodule Hedwig.Robot.Supervisor do
 
   def parse_config(robot, opts) do
     otp_app = Keyword.fetch!(opts, :otp_app)
-    config  = Application.get_env(otp_app, robot, [])
-    adapter = opts[:adapter] || config[:adapter]
+    robot_config  = Application.get_env(otp_app, robot, [])
+    adapter = opts[:adapter] || robot_config[:adapter]
 
     unless adapter do
       raise ArgumentError, "missing `:adapter` configuration for " <>
@@ -38,7 +38,7 @@ defmodule Hedwig.Robot.Supervisor do
                            "project dependency."
     end
 
-    {otp_app, adapter, config}
+    {otp_app, adapter, robot_config}
   end
 
   def init(:ok) do

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule Hedwig.Mixfile do
 
      # Test dependencies
      {:excoveralls, "~> 0.4", only: :test},
+     {:credo, "~> 0.3", only: [:dev, :test]},
 
      # Dev dependencies
      {:earmark, "~> 0.1", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"certifi": {:hex, :certifi, "0.3.0"},
+%{"bunt": {:hex, :bunt, "0.1.5"},
+  "certifi": {:hex, :certifi, "0.3.0"},
+  "credo": {:hex, :credo, "0.3.3"},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.11.1"},
   "excoveralls": {:hex, :excoveralls, "0.4.3"},


### PR DESCRIPTION
Another one, if you're interested ;)

I just addressed the actual warnings, which were all about variables having the same names as functions. It makes sense to avoid this so that there's no confusion about if you're referencing the variable or the function. Admittedly I'd say it matters the most for 0-arity functions, but still..

Credo mentioned other items possibly worth pursuing (with lower severity), but some or all of them may be more a matter of style.