### PR TITLE
Fix compile time warnings in v0.3.0

### DIFF
--- a/lib/hedwig/handlers/help.ex
+++ b/lib/hedwig/handlers/help.ex
@@ -22,9 +22,9 @@ defmodule Hedwig.Handlers.Help do
   defp process_help(msg, nickname) do
     help = Client.get(msg.client, :handlers)
     |> Enum.filter(fn {mod, _opts} -> not is_nil(mod.usage) end)
-    |> Enum.map_join "", fn {mod, _opts} ->
+    |> Enum.map_join("", fn {mod, _opts} ->
       replace_nickname(mod.usage, nickname)
-    end
+    end)
     reply(msg, Stanza.body(help))
   end
 

--- a/lib/hedwig/jid.ex
+++ b/lib/hedwig/jid.ex
@@ -24,7 +24,7 @@ defmodule Hedwig.JID do
   defstruct user: "", server: "", resource: ""
 
 
-  @doc """
+  @impldoc """
   Returns a string representation from a JID struct.
 
   ## Examples


### PR DESCRIPTION
Some formatting issues within the v0.3.0 tag cause errors when using the `--warning-as-errors` compile time flag with `mix`.

Backtrace:
```
$ mix compile --warnings-as-errors --force
Compiled lib/hedwig/client/supervisor.ex
Compiled lib/hedwig/config.ex
lib/hedwig/handlers/help.ex:25: warning: you are piping into a function call without parentheses, which may be ambiguous. Please wrap the function you are piping into in parentheses. For example:

    foo 1 |> bar 2 |> baz 3

Should be written as:

    foo(1) |> bar(2) |> baz(3)

Compiled lib/hedwig.ex
Compiled lib/hedwig/registry.ex
Compiled lib/hedwig/supervisor.ex
Compiled lib/hedwig/xml.ex
Compiled lib/hedwig/transport.ex
lib/hedwig/jid.ex:50: warning: redefining @doc attribute previously set at line 27
Compiled lib/hedwig/jid.ex
Compiled lib/hedwig/helpers.ex
Compiled lib/hedwig/xmlns.ex
Compiled lib/hedwig/conn/features.ex
Compiled lib/hedwig/handler.ex
Compiled lib/hedwig/client.ex
Compiled lib/hedwig/auth.ex
Compiled lib/hedwig/conn.ex
Compiled lib/hedwig/transports/tcp.ex
Compiled lib/hedwig/stanzas/iq.ex
Compiled lib/hedwig/stanzas/message.ex
Compiled lib/hedwig/handlers/echo.ex
Compiled lib/hedwig/handlers/great_success.ex
Compiled lib/hedwig/stanzas/presence.ex
Compiled lib/hedwig/handlers/help.ex
Compiled lib/hedwig/stanza/parser.ex
Compiled lib/hedwig/handlers/panzy.ex
Compiled lib/hedwig/stanza.ex
Compilation failed due to warnings while using the --warnings-as-errors option
```

Making some small formatting changes in the relevant files resolve these issues.

Backtrace:
```
$ mix compile --warnings-as-errors --force
Compiled lib/hedwig/client/supervisor.ex
Compiled lib/hedwig.ex
Compiled lib/hedwig/config.ex
Compiled lib/hedwig/registry.ex
Compiled lib/hedwig/supervisor.ex
Compiled lib/hedwig/xml.ex
Compiled lib/hedwig/transport.ex
Compiled lib/hedwig/jid.ex
Compiled lib/hedwig/helpers.ex
Compiled lib/hedwig/xmlns.ex
Compiled lib/hedwig/conn/features.ex
Compiled lib/hedwig/handler.ex
Compiled lib/hedwig/client.ex
Compiled lib/hedwig/auth.ex
Compiled lib/hedwig/conn.ex
Compiled lib/hedwig/transports/tcp.ex
Compiled lib/hedwig/stanzas/iq.ex
Compiled lib/hedwig/stanza/parser.ex
Compiled lib/hedwig/stanzas/message.ex
Compiled lib/hedwig/handlers/echo.ex
Compiled lib/hedwig/stanzas/presence.ex
Compiled lib/hedwig/handlers/great_success.ex
Compiled lib/hedwig/handlers/panzy.ex
Compiled lib/hedwig/handlers/help.ex
Compiled lib/hedwig/stanza.ex
Generated hedwig app
Consolidated List.Chars
Consolidated String.Chars
Consolidated Collectable
Consolidated Enumerable
Consolidated IEx.Info
Consolidated Inspect
```