### PR TITLE
Loop back into await/1 after processing a response

### DIFF
--- a/lib/hedwig/adapters/console.ex
+++ b/lib/hedwig/adapters/console.ex
@@ -81,18 +81,18 @@ defmodule Hedwig.Adapters.Console do
       loop(owner, user, name)
     end
 
-    def send_to_adapter(text, owner, name) do
+    def send_to_adapter(text, owner, name, timeout \\ 500) do
       Kernel.send(owner, {:message, text})
-      await(name)
+      await(name, timeout)
     end
 
-    defp await(name) do
+    defp await(name, timeout) do
       receive do
         {:reply, resp} ->
           handle_result(resp, name)
-          await(name)
+          await(name, timeout)
       after
-        500 -> :ok
+        timeout -> :ok
       end
     end
 

--- a/lib/hedwig/adapters/console.ex
+++ b/lib/hedwig/adapters/console.ex
@@ -90,6 +90,7 @@ defmodule Hedwig.Adapters.Console do
       receive do
         {:reply, resp} ->
           handle_result(resp, name)
+          await(name)
       after
         500 -> :ok
       end

--- a/lib/hedwig/adapters/console.ex
+++ b/lib/hedwig/adapters/console.ex
@@ -81,7 +81,7 @@ defmodule Hedwig.Adapters.Console do
       loop(owner, user, name)
     end
 
-    defp send_to_adapter(text, owner, name) do
+    def send_to_adapter(text, owner, name) do
       Kernel.send(owner, {:message, text})
       await(name)
     end

--- a/test/hedwig/adapters/console_test.exs
+++ b/test/hedwig/adapters/console_test.exs
@@ -1,0 +1,27 @@
+defmodule Hedwig.Adapters.ConsoleTest do
+  use ExUnit.Case
+
+  alias ExUnit.CaptureIO
+  alias Hedwig.Adapters.Console.Connection
+
+  test "console connection processes multiple responses" do
+    output = capture_and_normalize_io(fn ->
+      conn = spawn_link(Connection, :send_to_adapter, ["foo", self, "consoletest"])
+      assert_receive {:message, "foo"}
+      send(conn, {:reply, %Hedwig.Message{text: "bar"}})
+      send(conn, {:reply, %Hedwig.Message{text: "baaz"}})
+      :timer.sleep(500)
+    end)
+
+    assert output == ["consoletest> bar", "consoletest> baaz"]
+  end
+
+  defp capture_and_normalize_io(fun) do
+    CaptureIO.capture_io(fun)
+    |> strip_ansi()
+    |> split_on_eol()
+  end
+
+  defp strip_ansi(string), do: Regex.replace(~r/\e\[[^m]+m/, string, "")
+  defp split_on_eol(string), do: String.split(string, "\n", trim: true)
+end


### PR DESCRIPTION
If more than one responder matches a message, the robot will send multiple
responses. The console adapter, however, was only able to handle one respose
for each line of input it received. Fix this by making await/1 call itself
after a successful match, to receive any further messages waiting in the
mailbox.