### PR TITLE
Allow adapters to pass messages to the robot module

### DIFF
--- a/lib/hedwig/adapters/test.ex
+++ b/lib/hedwig/adapters/test.ex
@@ -10,7 +10,6 @@ defmodule Hedwig.Adapters.Test do
 
   def handle_cast(:after_init, %{robot: robot, opts: opts} = state) do
     Hedwig.Robot.after_connect(robot)
-    Hedwig.Robot.register(robot, opts[:name])
     {:noreply, state}
   end
 
@@ -32,6 +31,11 @@ defmodule Hedwig.Adapters.Test do
   def handle_info({:message, msg}, %{robot: robot} = state) do
     msg = %Hedwig.Message{text: msg.text, user: msg.user}
     Hedwig.Robot.handle_message(robot, msg)
+    {:noreply, state}
+  end
+
+  def handle_info(msg, %{robot: robot} = state) do
+    Hedwig.Robot.handle_in(robot, msg)
     {:noreply, state}
   end
 end

--- a/lib/hedwig/test/test_robot.ex
+++ b/lib/hedwig/test/test_robot.ex
@@ -3,7 +3,17 @@ Code.ensure_compiled(Hedwig.Adapters.Test)
 defmodule Hedwig.TestRobot do
   use Hedwig.Robot, otp_app: :hedwig, adapter: Hedwig.Adapters.Test
 
-  def after_connect(state) do
-    {:ok, state}
+  def after_connect(%{name: name} = robot) do
+    Hedwig.Robot.register(self, name)
+    {:ok, robot}
+  end
+
+  def handle_in({:ping, from}, robot) do
+    Kernel.send(from, :pong)
+    {:ok, robot}
+  end
+
+  def handle_in(msg, robot) do
+    {:ok, robot}
   end
 end

--- a/test/hedwig_test.exs
+++ b/test/hedwig_test.exs
@@ -11,4 +11,9 @@ defmodule HedwigTest do
     assert Hedwig.whereis("hedwig") == :undefined
     assert Hedwig.whereis("codsworth") == pid
   end
+  @tag start_robot: true
+  test "handle_in/2", %{robot: pid} do
+    Hedwig.Robot.handle_in(pid, {:ping, self()})
+    assert_receive :pong
+  end
 end


### PR DESCRIPTION
This allows users to define `handle_in/2` in their robot module
in order to handle any message no handled by the adapter.

Example:

```elixir
defmodule MyApp.Robot do
  use Hedwig.Robot, otp_app: :my_app

  def handle_in({:some_message, msg}, robot) do
    # do something with the message ...
    # must return `{:ok, robot}`.
    # `robot` here is the state of the Robot.
    {:ok, robot}
  end
end
```