### PR TITLE
Small documentation change

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ msg = %Hedwig.Message{
 }
 
 # Send the message
-Alfred.Robot.send(pid, msg)
+Hedwig.Robot.send(pid, msg)
 ```
 
 


### PR DESCRIPTION
In the **Sending Messages** section, it's recommend that users run this command to send a message to the robot that they've created:

```elixir
Alfred.Robot.send(pid, msg)
```

This will necessarily result in an error. This PR fixes that.