### PR TITLE
Responders can set bot identity via module attributes

### DIFF
--- a/lib/hedwig/adapters/console/writer.ex
+++ b/lib/hedwig/adapters/console/writer.ex
@@ -42,7 +42,11 @@ defmodule Hedwig.Adapters.Console.Writer do
   end
 
   defp handle_result(msg, name) do
-    print prompt(name) ++ [:normal, :default_color, msg.text]
+    from = case msg do
+      %Hedwig.Message{private: %{identity: %{name: bot_name}}} -> bot_name
+      _ -> name
+    end
+    print prompt(from) ++ [:normal, :default_color, msg.text]
   end
 
   defp prompt(name) do

--- a/lib/hedwig/test/robot_case.ex
+++ b/lib/hedwig/test/robot_case.ex
@@ -2,7 +2,9 @@ defmodule Hedwig.RobotCase do
   use ExUnit.CaseTemplate
 
   @robot Hedwig.TestRobot
-  @default_responders [{Hedwig.Responders.Help, []}, {TestResponder, []}]
+  @default_responders [{Hedwig.Responders.Help, []}, 
+                       {TestResponder, []},
+                       {TestIdentityResponder, []}]
 
   using do
     quote do

--- a/test/hedwig/identity_responder_test.exs
+++ b/test/hedwig/identity_responder_test.exs
@@ -1,0 +1,15 @@
+defmodule Hedwig.IdentityResponderTest do
+  use Hedwig.RobotCase
+
+  @tag start_robot: true, name: "alfred"
+  test "responding with bot identity", %{adapter: adapter, msg: msg} do
+    send adapter, {:message, %{msg | text: "whats up"}}
+    assert_receive {:message, 
+      %{text: "the sky!", private: %{identity: %{name: "Cool Bot"}}}}
+  end
+
+  test "bot_identity" do
+    assert TestIdentityResponder.bot_identity(nil, nil) ==
+      %{name: "Cool Bot", emoji: ":sunglasses:", thumbnail: nil}
+  end
+end

--- a/test/hedwig/responder_test.exs
+++ b/test/hedwig/responder_test.exs
@@ -3,6 +3,11 @@ defmodule Hedwig.ResponderTest do
 
   alias Hedwig.Responder
 
+  test "bot_identity" do
+    assert TestResponder.bot_identity(nil, nil) ==
+      %{name: nil, thumbnail: nil, emoji: nil}
+  end
+
   test "respond_pattern" do
     assert Responder.respond_pattern(~r/hey there/i, "alfred", nil) ==
       ~r/^\s*[@]?alfred[:,]?\s*(?:hey there)/i
@@ -31,5 +36,8 @@ defmodule Hedwig.ResponderTest do
     send adapter, {:message, %{msg | text: "randomness"}}
     assert_receive {:message, %{text: text}}
     assert text in 1..1000
+
+    send adapter, {:message, %{msg | text: "promote me"}}
+    assert_receive {:message, %{text: "yessir", private: %{rank: "captain"}}}
   end
 end

--- a/test/support/test_identity_responder.ex
+++ b/test/support/test_identity_responder.ex
@@ -1,0 +1,13 @@
+defmodule TestIdentityResponder do
+  use Hedwig.Responder
+
+  @bot_name "Cool Bot"
+  @bot_emoji ":sunglasses:"
+
+  @usage """
+  (whats up) - the sky!
+  """
+  hear ~r/whats up/i, msg do
+    send msg, "the sky!"
+  end
+end

--- a/test/support/test_responder.ex
+++ b/test/support/test_responder.ex
@@ -1,6 +1,6 @@
 defmodule TestResponder do
   use Hedwig.Responder
-
+  
   @usage """
   (this is a test) - did someone say test?
   """
@@ -34,5 +34,12 @@ defmodule TestResponder do
   """
   hear ~r/randomness/i, msg do
     send msg, random(Enum.to_list(1..1000))
+  end
+
+  @usage """
+  set private data
+  """
+  hear ~r/promote me/i, msg do
+    send %{msg | private: %{rank: "captain"}}, "yessir"
   end
 end


### PR DESCRIPTION
First go at implementing bot identities in responders. Responders can define `@bot_name`, `@bot_emoji`, `@bot_thumbnail` attributes that will be used with their messages when doing a `send` or `emote` (but not `reply`). The name must be overridden for this to take effect.

Identity is used (name only) in the console adapter.

Additionally, `bot_identity/2` can be overridden by the individual responder to allow for custom behavior. See labzero/hedwig_simple_responders@6ff56081cf6a82e1f3e7e77c1dcc1c058968c572 for an example of this.