### PR TITLE
Clean up elixir 1.4 compile warnings

### DIFF
--- a/lib/hedwig/adapter.ex
+++ b/lib/hedwig/adapter.ex
@@ -7,8 +7,6 @@ defmodule Hedwig.Adapter do
   `Hedwig.Message` struct and call `Hedwig.Robot.handle_message(robot, msg)`.
   """
 
-  use Behaviour
-
   @doc false
   defmacro __using__(_opts) do
     quote do
@@ -57,7 +55,7 @@ defmodule Hedwig.Adapter do
 
   @doc false
   def start_link(module, opts) do
-    GenServer.start_link(module, {self, opts})
+    GenServer.start_link(module, {self(), opts})
   end
 
   @type robot :: pid
@@ -65,7 +63,7 @@ defmodule Hedwig.Adapter do
   @type opts  :: any
   @type msg   :: Hedwig.Message.t
 
-  defcallback send(pid, msg) :: term
-  defcallback reply(pid, msg) :: term
-  defcallback emote(pid, msg) :: term
+  @callback send(pid, msg) :: term
+  @callback reply(pid, msg) :: term
+  @callback emote(pid, msg) :: term
 end

--- a/lib/hedwig/adapters/test.ex
+++ b/lib/hedwig/adapters/test.ex
@@ -4,7 +4,7 @@ defmodule Hedwig.Adapters.Test do
   use Hedwig.Adapter
 
   def init({robot, opts}) do
-    GenServer.cast(self, :after_init)
+    GenServer.cast(self(), :after_init)
     {:ok, %{conn: nil, opts: opts, robot: robot}}
   end
 

--- a/lib/mix/tasks/hedwig.gen.robot.ex
+++ b/lib/mix/tasks/hedwig.gen.robot.ex
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Hedwig.Gen.Robot do
     robot   = opts[:robot] || default_robot(app)
     adapter = get_adapter_module(deps)
 
-    underscored = Mix.Utils.underscore(robot)
+    underscored = Macro.underscore(robot)
     file = Path.join("lib", underscored) <> ".ex"
 
     robot = Module.concat([robot])
@@ -79,7 +79,7 @@ defmodule Mix.Tasks.Hedwig.Gen.Robot do
 
   defp default_robot(app) do
     case Application.get_env(app, :app_namespace, app) do
-      ^app -> app |> to_string |> Mix.Utils.camelize
+      ^app -> app |> to_string |> Macro.camelize
       mod  -> mod |> inspect
     end |> Module.concat(Robot)
   end

--- a/lib/mix/tasks/hedwig.gen.robot.ex
+++ b/lib/mix/tasks/hedwig.gen.robot.ex
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Hedwig.Gen.Robot do
     """]
 
     aka     = opts[:aka]   || "/"
-    name    = opts[:name]  || prompt_for_name
+    name    = opts[:name]  || prompt_for_name()
     robot   = opts[:robot] || default_robot(app)
     adapter = get_adapter_module(deps)
 
@@ -87,7 +87,7 @@ defmodule Mix.Tasks.Hedwig.Gen.Robot do
   defp available_adapters(deps) do
     deps
     |> all_modules
-    |> Kernel.++(hedwig_modules)
+    |> Kernel.++(hedwig_modules())
     |> Enum.uniq
     |> Enum.filter(&implements_adapter?/1)
     |> Enum.with_index


### PR DESCRIPTION
No changes of substance, just small changes to get rid of elixir 1.4 compile warnings.