### PR TITLE
Allow modules to define collections of responders

### DIFF
--- a/test/hedwig/robot_test.exs
+++ b/test/hedwig/robot_test.exs
@@ -12,6 +12,25 @@ defmodule Hedwig.RobotTest do
     assert [{TestResponder, []}] = Hedwig.Robot.responders(robot)
   end
 
+  def collection_fill_opts(opts), do: [{A, opts}, {B, opts}]
+
+  @tag start_robot: true, responders: [{Hedwig.RobotTest, :collection_fill_opts, [foo: "bar"]}]
+  test "collect_responders/1 expands responder list with common options", %{robot: robot} do
+    assert [{A, [foo: "bar"]}, {B, [foo: "bar"]}] = Hedwig.Robot.responders(robot)
+  end
+
+  def collection_empty_opts(_opts), do: [{A, []}, {B, []}]
+
+  @tag start_robot: true, responders: [{Hedwig.RobotTest, :collection_empty_opts, [foo: "bar"]}]
+  test "collect_responders/1 expands responder list", %{robot: robot} do
+    assert [{A, []}, {B, []}] = Hedwig.Robot.responders(robot)
+  end
+
+  @tag start_robot: true, responders: [{TestResponder, []}, {Hedwig.RobotTest, :collection_empty_opts, []}]
+  test "collect_responders/1 includes normal responder definition at start", %{robot: robot} do
+    assert [{TestResponder, []}, {A, []}, {B, []}] = Hedwig.Robot.responders(robot)
+  end
+
   @tag start_robot: true
   test "handle_connect/1", %{robot: robot} do
     assert ^robot = :global.whereis_name("hedwig")


### PR DESCRIPTION
In some cases it is convenient to define a collection of responders outside of the bot's configuration file, and then to reference that collection as a list of responders to load with the bot.

Ex.:

Instead of:
```
config :testbot, Testbot.Robot,
  responders: [
    {Hedwig.Responders.Help, []},
    {Hedwig.Responders.Ping, []},
    {HedwigGithub.Responder, []},
    {HedwigPlusPlus.Responder, []},
    {HedwigSimpleResponders.BeerMe, []},
    {HedwigSimpleResponders.Echo, []},
    {HedwigSimpleResponders.Fishpun, []},
    {HedwigSimpleResponders.Flip, []},
    {HedwigSimpleResponders.Manatee, []},
    {HedwigSimpleResponders.PugMe, []},
    {HedwigSimpleResponders.Shingy, []},
    {HedwigSimpleResponders.ShipIt, []},
    {HedwigSimpleResponders.Slime, []},
    {HedwigSimpleResponders.Slogan, []},
    {HedwigSimpleResponders.Stallman, []},
    {HedwigSimpleResponders.Time, []},
    {HedwigSimpleResponders.Toot, []},
    {HedwigSimpleResponders.TroutSlap, []},
    {HedwigWunderground.Responder, []},
    {HedwigMopidy.Responders.Mopidy, []},
    {HedwigSimpleResponders.Uptime, []}
  ]
```

It becomes possible to delegate selection of responders:
```
config :testbot, Testbot.Robot,
  responders: [
    {Hedwig.Responders.Help, []},
    {Hedwig.Responders.Ping, []},
    {HedwigSimpleResponders, :all, []}, # <--
    {HedwigPlusPlus.Responder, []},
    {HedwigWunderground.Responder, []},
    {HedwigMopidy.Responders.Mopidy, []}
  ]
```

Any options defined with the collection are in turn passed to the collector function.