### PR TITLE
Fix Elixir 1.5 compile warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ erl_crash.dump
 /log
 /test/tmp
 /cover
-*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ erl_crash.dump
 /log
 /test/tmp
 /cover
+*.DS_Store

--- a/lib/hedwig/adapters/console/connection.ex
+++ b/lib/hedwig/adapters/console/connection.ex
@@ -43,6 +43,6 @@ defmodule Hedwig.Adapters.Console.Connection do
   defp get_system_user do
     System.cmd("whoami", [])
     |> elem(0)
-    |> String.strip()
+    |> String.trim()
   end
 end

--- a/lib/hedwig/adapters/console/reader.ex
+++ b/lib/hedwig/adapters/console/reader.ex
@@ -31,7 +31,7 @@ defmodule Hedwig.Adapters.Console.Reader do
   end
 
   def handle_info(text, {owner, user}) when is_binary(text) do
-    Kernel.send(owner, {:message, String.strip(text)})
+    Kernel.send(owner, {:message, String.trim(text)})
     Process.sleep(200)
     GenServer.cast(self(), :get_io)
 

--- a/lib/hedwig/responder.ex
+++ b/lib/hedwig/responder.ex
@@ -180,7 +180,7 @@ defmodule Hedwig.Responder do
       @doc false
       def usage(name) do
         import String
-        Enum.map(@usage, &(&1 |> strip |> replace("hedwig", name)))
+        Enum.map(@usage, &(&1 |> trim |> replace("hedwig", name)))
       end
 
       def init({aka, name, opts, robot}) do

--- a/lib/mix/tasks/hedwig.gen.robot.ex
+++ b/lib/mix/tasks/hedwig.gen.robot.ex
@@ -137,7 +137,7 @@ defmodule Mix.Tasks.Hedwig.Gen.Robot do
 
   defp prompt_for_name do
     Mix.shell.prompt("What would you like to name your bot?:")
-    |> String.strip
+    |> String.trim
   end
 
   defp prompt_for_adapter(adapters) do


### PR DESCRIPTION
Fixes the Elixir 1.5 compile warnings when running `mix hedwig.gen.robot`

Added `*.DS_Store` to the .gitignore file as well to prevent accidental adding of macOS drive files.